### PR TITLE
ci: removing PR limit from renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -47,7 +47,6 @@
   "postUpdateOptions": [
     "gomodTidy"
   ],
-  "prConcurrentLimit": 2,
   "schedule": [
     "every weekend"
   ],


### PR DESCRIPTION
Removing PR limit from renovate to allow it to create as many PRs as it needs.
